### PR TITLE
Updated installation_guide.md (Fixes issue #5 )

### DIFF
--- a/edit_documentation_here/source/installation_guide/installation_guide.md
+++ b/edit_documentation_here/source/installation_guide/installation_guide.md
@@ -134,17 +134,10 @@ Install InVesalius main dependencies **wxpython**, **numpy**, **scipy**, **VTK**
 **scikit-image**, **Pillow**, **Pyserial**, **PSUtil**, **nibabel**, **configparser**, **H5py**, **PyPubsub** 
 and **plaidml** using pip:
 
-1. If using Mac with Intel:
-
 ```shell
 pip3 install -r requirements.txt
 ```
 
-2. If using Mac with Apple Silicon:
-
-```
-pip3 install -r requirements_m1.txt
-```
 ### Compiling InVesalius
 
 If you are using Mac with Apple Silicon, you need to export some environment variable before the next step:


### PR DESCRIPTION
changed the documentation for macOS installation and downdloading requirments to correctly use requirments.txt for both Intel macs and Apple Silicon

before:
<img width="811" alt="image" src="https://github.com/user-attachments/assets/0af5801f-47ce-4f7f-85bb-9792e51abb1b" />

after:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/35f15795-22f6-4478-b5b8-e1a04b29ac63" />

Fixes issue #5 
